### PR TITLE
- beep.go: removed unit test of NewBeepContext b/c it tries to init a…

### DIFF
--- a/pkg/audio/beep.go
+++ b/pkg/audio/beep.go
@@ -49,6 +49,7 @@ type beepContext struct {
 }
 
 func NewBeepContext() (Context, error) {
+	// notest
 	sampleRate := beep.SampleRate(44100)
 	// XXX: This should probably be done somewhere else... it doesn't need to be initialized every time.
 	err := speaker.Init(sampleRate, sampleRate.N(time.Second/10))

--- a/pkg/audio/beep_test.go
+++ b/pkg/audio/beep_test.go
@@ -25,12 +25,6 @@ import (
 	"testing"
 )
 
-func TestNewBeepContext(t *testing.T) {
-	ctx, err := NewBeepContext()
-	assert.Nil(t, err)
-	assert.NotNil(t, ctx)
-}
-
 func TestBeepContext_PlayerFor(t *testing.T) {
 	ctx := &beepContext{}
 	player, err := ctx.PlayerFor("../../test/data/library/multi-level/hh.wav")


### PR DESCRIPTION
… speaker which shouldn't happen in a unit test.